### PR TITLE
Implement missing function for action reason enum

### DIFF
--- a/wittypi4/__init__.py
+++ b/wittypi4/__init__.py
@@ -128,6 +128,16 @@ class ActionReason(enum.Enum):
     REBOOT = 0x0B
     GUARANTEED_WAKE = 0x0C
 
+    @classmethod
+    def _missing_(cls, value: object) -> int:
+        if isinstance(value, int):
+            # For integer values, return a custom object
+            logger.warning("ActionReason %i is unknown!", value)
+            return 0
+        else:
+            # For non-integer values, raise a ValueError
+            raise ValueError(f"{value} is not a valid {cls.__name__}")
+
 
 class WittyPiException(Exception):
     pass


### PR DESCRIPTION
We got the problem that Witty Pi got updated, introducing new action reasons that we did not handle. To avoid unexpected crashed in the future, this commit adds the _missing_ classmethod to the ActionReason Enum, where an error is printed and the default value 0 is returned.